### PR TITLE
Add portfolio section with drive video support

### DIFF
--- a/assets/free.svg
+++ b/assets/free.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="40">
+  <rect width="80" height="40" rx="8" fill="#e0ffe0" />
+  <text x="40" y="25" font-size="16" text-anchor="middle" fill="#2e7d32" font-family="Arial, sans-serif">FREE</text>
+</svg>

--- a/assets/paid.svg
+++ b/assets/paid.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="40">
+  <rect width="80" height="40" rx="8" fill="#ffe0e0" />
+  <text x="40" y="25" font-size="16" text-anchor="middle" fill="#c62828" font-family="Arial, sans-serif">PAID</text>
+</svg>

--- a/assets/portfolio.js
+++ b/assets/portfolio.js
@@ -1,0 +1,31 @@
+// assets/portfolio.js
+
+function escapeHtml(s){return String(s||'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]))}
+
+async function loadAndRenderPortfolio(basePath="."){
+  try{
+    const res = await fetch(`${basePath}/config/portfolio.json?ts=${Date.now()}`);
+    const data = await res.json();
+    renderPortfolio(data.items || []);
+  }catch(e){ console.error("Portfolio load error:",e); }
+}
+
+function renderPortfolio(items){
+  const container = document.getElementById('portfolio');
+  if(!container) return;
+  container.innerHTML='';
+  items.forEach(it=>{
+    const el = document.createElement('div');
+    el.className='portfolio-item';
+    el.innerHTML=`
+      <div class="video-wrapper">
+        <video controls src="${escapeHtml(it.video)}"></video>
+        <img class="flag" src="assets/${it.paid?'paid':'free'}.svg" alt="${it.paid?'Berbayar':'Gratis'}">
+      </div>
+      <p class="desc">${escapeHtml(it.description)}</p>
+    `;
+    container.appendChild(el);
+  });
+}
+
+window.Portfolio = { loadAndRender: loadAndRenderPortfolio };

--- a/config/portfolio.json
+++ b/config/portfolio.json
@@ -1,0 +1,16 @@
+{
+  "items": [
+    {
+      "title": "Contoh Video Gratis",
+      "description": "Proyek gratis untuk promosi internal.",
+      "video": "https://drive.google.com/uc?export=download&id=FILE_ID_GRATIS",
+      "paid": false
+    },
+    {
+      "title": "Contoh Video Berbayar",
+      "description": "Proyek berbayar bersama klien.",
+      "video": "https://drive.google.com/uc?export=download&id=FILE_ID_BAYAR",
+      "paid": true
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -28,6 +28,15 @@
 
     .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:20px}
 
+    /* ===== Portfolio ===== */
+    .portfolio-section h2{margin:40px 0 16px;font-size:18px}
+    .portfolio-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:20px}
+    .portfolio-item{background:var(--card);padding:12px;border-radius:12px}
+    .portfolio-item .video-wrapper{position:relative}
+    .portfolio-item video{width:100%;border-radius:8px;background:#000}
+    .portfolio-item .flag{position:absolute;top:8px;left:8px;width:60px;height:auto;border-radius:4px}
+    .portfolio-item .desc{color:var(--muted);margin-top:8px;font-size:14px}
+
     .card{border-radius:12px;overflow:hidden;transition:height .3s ease;position:relative}
     .card-face{background:var(--card);border-radius:12px;padding:18px;
       box-shadow:0 6px 18px rgba(0,0,0,0.6);border:2px solid rgba(255,255,255,0.05);
@@ -75,10 +84,16 @@
 
     <section class="grid" id="packages"></section>
 
+    <section class="portfolio-section">
+      <h2>Portofolio</h2>
+      <div class="portfolio-grid" id="portfolio"></div>
+    </section>
+
     <footer><small>© KuhyaKuya Studio</small></footer>
   </main>
 
   <script src="assets/pricing.js"></script>
+  <script src="assets/portfolio.js"></script>
   <script>
     const texts=[
       "Harga transparan, kerjaan adil. Satu klik untuk hasil terbaik bagi client dan freelancer.",
@@ -157,6 +172,7 @@
     function numberWithSeparators(x){return x?.toString().replace(/\B(?=(\d{3})+(?!\d))/g,',')||'0'}
     function escapeHtml(s){return String(s||'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]))}
     loadPackages();
+    Portfolio.loadAndRender();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add dynamic portfolio section with Drive-hosted videos and free/paid badges
- introduce portfolio.json and portfolio.js for easy portfolio management
- include SVG icons for free and paid projects

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c5082cc298832792f779dd971108b9