### PR TITLE
Support Google Drive preview links in portfolio

### DIFF
--- a/assets/portfolio.js
+++ b/assets/portfolio.js
@@ -17,9 +17,13 @@ function renderPortfolio(items){
   items.forEach(it=>{
     const el = document.createElement('div');
     el.className='portfolio-item';
+    const isDrivePreview = /https:\/\/drive\.google\.com\/file\/d\/.+\/preview/.test(it.video||'');
+    const media = isDrivePreview
+      ? `<iframe src="${escapeHtml(it.video)}" allow="autoplay" allowfullscreen></iframe>`
+      : `<video controls src="${escapeHtml(it.video)}"></video>`;
     el.innerHTML=`
       <div class="video-wrapper">
-        <video controls src="${escapeHtml(it.video)}"></video>
+        ${media}
         <img class="flag" src="assets/${it.paid?'paid':'free'}.svg" alt="${it.paid?'Berbayar':'Gratis'}">
       </div>
       <p class="desc">${escapeHtml(it.description)}</p>

--- a/config/portfolio.json
+++ b/config/portfolio.json
@@ -9,7 +9,7 @@
     {
       "title": "Contoh Video Berbayar",
       "description": "Proyek berbayar bersama klien.",
-      "video": "https://drive.google.com/uc?export=download&id=FILE_ID_BAYAR",
+      "video": "https://drive.google.com/file/d/1F5qmL7EKMOeLqY4NJH_ngLWGyN7PxhEZ/preview",
       "paid": true
     }
   ]

--- a/index.html
+++ b/index.html
@@ -33,7 +33,8 @@
     .portfolio-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:20px}
     .portfolio-item{background:var(--card);padding:12px;border-radius:12px}
     .portfolio-item .video-wrapper{position:relative}
-    .portfolio-item video{width:100%;border-radius:8px;background:#000}
+    .portfolio-item video,
+    .portfolio-item iframe{width:100%;border-radius:8px;background:#000;border:none}
     .portfolio-item .flag{position:absolute;top:8px;left:8px;width:60px;height:auto;border-radius:4px}
     .portfolio-item .desc{color:var(--muted);margin-top:8px;font-size:14px}
 


### PR DESCRIPTION
## Summary
- Render Google Drive preview links with an iframe so videos play correctly
- Style portfolio iframes like video elements
- Use provided dummy Google Drive link in portfolio config

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c50cf0126883278ef95eb5c77bc73b