### PR TITLE
Handle video load errors in portfolio

### DIFF
--- a/assets/portfolio.js
+++ b/assets/portfolio.js
@@ -28,6 +28,15 @@ function renderPortfolio(items){
       </div>
       <p class="desc">${escapeHtml(it.description)}</p>
     `;
+    if(!isDrivePreview){
+      const video = el.querySelector('video');
+      const wrapper = el.querySelector('.video-wrapper');
+      if(video && wrapper){
+        video.addEventListener('error',()=>{
+          wrapper.innerHTML=`Video tidak tersedia <a href="${escapeHtml(it.video)}" download>Download video</a>`;
+        });
+      }
+    }
     container.appendChild(el);
   });
 }


### PR DESCRIPTION
## Summary
- Add error listener to portfolio video elements to show fallback message and download link when playback fails.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c50f5f767083279cf3e4e2f808964f