### PR TITLE
fix: responsive GDrive iframe & thumbnail fallback on portfolio section

### DIFF
--- a/assets/portfolio.js
+++ b/assets/portfolio.js
@@ -23,13 +23,14 @@ function renderPortfolio(items){
   if(!container) return;
   container.innerHTML='';
   items.forEach(it=>{
-    const el = document.createElement('div');
+    const el=document.createElement('div');
     el.className='portfolio-item';
-    const video = toDrivePreviewLink(it.video);
-    const isDrive = /drive\.google\.com/.test(video||'');
-    const media = isDrive
-      ? `<iframe src="${escapeHtml(video)}" allow="autoplay" allowfullscreen></iframe>`
-      : `<video controls src="${escapeHtml(video)}"></video>`;
+    const videoUrl=toDrivePreviewLink(it.video);
+    const isDrive=/drive\.google\.com/.test(videoUrl||'');
+    const thumb=it.thumbnail||'img/placeholder.svg'; // thumbnail fallback
+    const media=isDrive
+      ? `<img class="thumb" src="${escapeHtml(thumb)}" alt="thumbnail"><iframe src="${escapeHtml(videoUrl)}" allow="autoplay" allowfullscreen></iframe>`
+      : `<video controls src="${escapeHtml(videoUrl)}" poster="${escapeHtml(thumb)}"></video>`; // apply thumb
     el.innerHTML=`
       <div class="video-wrapper">
         ${media}
@@ -37,12 +38,20 @@ function renderPortfolio(items){
       </div>
       <p class="desc">${escapeHtml(it.description)}</p>
     `;
-    if(!isDrivePreview){
-      const video = el.querySelector('video');
-      const wrapper = el.querySelector('.video-wrapper');
-      if(video && wrapper){
-        video.addEventListener('error',()=>{
-          wrapper.innerHTML=`Video tidak tersedia <a href="${escapeHtml(it.video)}" download>Download video</a>`;
+    if(isDrive){
+      const t=el.querySelector('.thumb');
+      if(t){t.addEventListener('error',()=>{t.src='img/placeholder.svg';});}
+      const f=el.querySelector('iframe');
+      if(f&&t){f.addEventListener('load',()=>{t.remove();});}
+    }else{
+      const v=el.querySelector('video');
+      const w=el.querySelector('.video-wrapper');
+      const chk=new Image();
+      chk.src=thumb;
+      chk.onerror=()=>{v.setAttribute('poster','img/placeholder.svg');}; // ensure thumb exists
+      if(v&&w){
+        v.addEventListener('error',()=>{
+          w.innerHTML=`Video tidak tersedia <a href="${escapeHtml(it.video)}" download>Download video</a>`;
         });
       }
     }

--- a/img/placeholder.svg
+++ b/img/placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 90">
+  <rect width="160" height="90" fill="#555"/>
+  <text x="80" y="45" fill="#888" font-size="12" dominant-baseline="middle" text-anchor="middle">No thumbnail</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -32,9 +32,10 @@
     .portfolio-section h2{margin:40px 0 16px;font-size:18px}
     .portfolio-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:20px}
     .portfolio-item{background:var(--card);padding:12px;border-radius:12px}
-    .portfolio-item .video-wrapper{position:relative}
-    .portfolio-item video,
-    .portfolio-item iframe{width:100%;border-radius:8px;background:#000;border:none}
+    .portfolio-item .video-wrapper{position:relative;aspect-ratio:16/9} /* responsive 16:9 */
+    .portfolio-item .video-wrapper iframe,
+    .portfolio-item .video-wrapper video{position:absolute;top:0;left:0;width:100%;height:100%;border-radius:8px;background:#000;border:none} /* full-size media */
+    .portfolio-item .video-wrapper .thumb{position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;border-radius:8px;background:#000} /* thumb fallback */
     .portfolio-item .flag{position:absolute;top:8px;left:8px;width:60px;height:auto;border-radius:4px}
     .portfolio-item .desc{color:var(--muted);margin-top:8px;font-size:14px}
 


### PR DESCRIPTION
## Summary
- make Google Drive portfolio iframes responsive with a 16:9 aspect ratio
- add thumbnail support with placeholder fallback

## Testing
- `node --check assets/portfolio.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c52716ec7c8327943f85b266ea4689