### PR TITLE
fix: change Show Portofolio button to Valorant-style diamond checklist

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,9 +38,10 @@
     .portfolio-item .flag{position:absolute;top:8px;left:8px;width:60px;height:auto;border-radius:4px} /* flag badge */
     .portfolio-item .desc{color:var(--muted);margin-top:8px;font-size:14px} /* portfolio text */
     .portfolio-toggle{display:flex;align-items:center;gap:8px;margin-bottom:12px} /* toggle container */
-    .diamond-btn{width:24px;height:24px;border:2px solid var(--accent);background:none;transform:rotate(45deg);cursor:pointer;position:relative} /* diamond button style */
-    .diamond-btn.active{background:var(--accent)} /* active fill */
-    .diamond-btn.active::after{content:'';position:absolute;top:50%;left:50%;width:6px;height:12px;border:2px solid #fff;border-top:0;border-left:0;transform:translate(-50%,-60%) rotate(45deg)} /* check mark */
+    .diamond-btn{width:40px;height:40px;border:2px solid var(--accent);background:transparent;transform:rotate(45deg);cursor:pointer;position:relative} /* diamond button style */ /* changed size & transparency */
+    .diamond-btn .check{position:absolute;top:50%;left:50%;width:12px;height:20px;border:3px solid #fff;border-top:0;border-left:0;transform:translate(-50%,-60%) rotate(-45deg);display:none} /* check mark element */ /* counter-rotate */
+    .diamond-btn.active{background:var(--accent)} /* active fill */ /* shows accent when active */
+    .diamond-btn.active .check{display:block} /* show check on active */
 
     .card{border-radius:12px;overflow:hidden;transition:height .3s ease;position:relative}
     .card-face{background:var(--card);border-radius:12px;padding:18px;
@@ -91,9 +92,11 @@
 
     <section class="portfolio-section">
       <h2>Portofolio</h2>
-      <div class="portfolio-toggle"> <!-- Show/Hide button -->
-        <button id="pfToggle" class="btn detail">Show Portofolio</button> <!-- toggle button -->
-      </div>
+        <div class="portfolio-toggle"> <!-- Show/Hide button -->
+          <button id="pfToggle" class="diamond-btn" aria-label="Show Portofolio"> <!-- diamond checklist button -->
+            <span class="check"></span> <!-- white check icon -->
+          </button>
+        </div>
       <div class="portfolio-grid" id="portfolio" style="display:none"></div> <!-- hidden by default -->
     </section>
 
@@ -181,13 +184,13 @@
     function escapeHtml(s){return String(s||'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]))}
     loadPackages();
     Portfolio.loadAndRender();
-    const pfToggle=document.getElementById('pfToggle'); // get toggle button
-    const pfGrid=document.getElementById('portfolio'); // get portfolio list
-    pfToggle.addEventListener('click',()=>{ // attach click handler
-      const show=pfGrid.style.display==='none'; // determine state
-      pfGrid.style.display=show?'':'none'; // show/hide list
-      pfToggle.textContent=show?'Hide Portofolio':'Show Portofolio'; // update label
-    }); // end handler
+      const pfToggle=document.getElementById('pfToggle'); // get diamond button
+      const pfGrid=document.getElementById('portfolio'); // get portfolio list
+      pfToggle.addEventListener('click',()=>{ // attach click handler
+        const show=pfGrid.style.display==='none'; // determine state
+        pfGrid.style.display=show?'':'none'; // show/hide list
+        pfToggle.classList.toggle('active',show); // toggle checkmark
+      }); // end handler
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- transform Show Portofolio button into a 40px diamond checklist with Valorant-style visuals
- toggle portfolio visibility by switching the button's active state and checkmark

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c53c36599483278855f042a1e83971