### PR TITLE
marketing: adjust package prices to psychological pricing (e.g. 49.900) to attract users

### DIFF
--- a/config/prices.json
+++ b/config/prices.json
@@ -12,52 +12,60 @@
   },
   "packages": [
     {
-  "id": 4,
-  "name": "Paket Gabut",
-  "price": 0,
-  "revisions": 0,
-  "durationText": "Terserah editor",
-  "overRatePerMin": 0,
-  "leadTime": "Tidak ada deadline",
-  "workloadPerMin": 1095,
-  "disabled": true, 
-  "features": [
-    "Kualitas menyesuaikan mood editor",
-    "Semua aspek ditentukan oleh editor"
-  ],
-  "tags": ["Random", "Eksperimen"],
-  "policies": [
-    "Editor berhak berhenti di tengah proses editing, jika dirasa jenuh",
-    "Edit sesuai mood editor",
-    "Musik bebas terserah editor",
-    "Tidak ada revisi",
-    "Gratis (harga 0)",
-    "Boleh dipakai untuk portofolio editor",
-    "Konsep terserah editor",
-    "Tidak ada deadline",
-    "Editor berhak menolak projek jika file RAW dinilai tidak berkualitas",
-    "Klien tidak berhak complain atas hasil editing",
-    "Copyright dipegang editor",
-    "Klien boleh memberi saran, tapi tidak mengikat editor"
-  ]
-},
+      "id": 4,
+      "name": "Paket Gabut",
+      "price": 0,
+      "revisions": 0,
+      "durationText": "Terserah editor",
+      "overRatePerMin": 0,
+      "leadTime": "Tidak ada deadline",
+      "workloadPerMin": 1095,
+      "disabled": true,
+      "features": [
+        "Kualitas menyesuaikan mood editor",
+        "Semua aspek ditentukan oleh editor"
+      ],
+      "tags": [
+        "Random",
+        "Eksperimen"
+      ],
+      "policies": [
+        "Editor berhak berhenti di tengah proses editing, jika dirasa jenuh",
+        "Edit sesuai mood editor",
+        "Musik bebas terserah editor",
+        "Tidak ada revisi",
+        "Gratis (harga 0)",
+        "Boleh dipakai untuk portofolio editor",
+        "Konsep terserah editor",
+        "Tidak ada deadline",
+        "Editor berhak menolak projek jika file RAW dinilai tidak berkualitas",
+        "Klien tidak berhak complain atas hasil editing",
+        "Copyright dipegang editor",
+        "Klien boleh memberi saran, tapi tidak mengikat editor"
+      ]
+    },
     {
       "id": 1,
       "name": "Paket InstaClip",
-      "price": 15000,
+      "price": 49900,
       "revisions": 1,
       "durationText": "1–5 menit",
       "overRatePerMin": 5000,
       "leadTime": "0–2 hari",
       "workloadPerMin": 0.5,
-      "disabled": false, 
+      "disabled": false,
       "features": [
         "cut basic",
         "overlay & sederhana",
         "add backsound",
         "Gratis Revisi 1x"
       ],
-      "tags": ["Konten TikTok/Reels", "Highlight Gaming", "Video pendek promosi", "Video Tugas"],
+      "tags": [
+        "Konten TikTok/Reels",
+        "Highlight Gaming",
+        "Video pendek promosi",
+        "Video Tugas"
+      ],
       "policies": [
         "Revisi gratis 1x. Lebih dari itu dikenakan IDR 10.000/revisi.",
         "Revisi hanya berlaku untuk perubahan minor sesuai brief awal.",
@@ -75,13 +83,13 @@
     {
       "id": 2,
       "name": "Paket Standar",
-      "price": 70000,
+      "price": 124900,
       "revisions": 2,
       "durationText": "1–5 menit",
       "overRatePerMin": 12000,
       "leadTime": "1–3 hari",
       "workloadPerMin": 1,
-      "disabled": false, 
+      "disabled": false,
       "features": [
         "cut + merge kompleks",
         "overlay + efek basic",
@@ -91,7 +99,12 @@
         "filter warna dasar",
         "Gratis Revisi 2x"
       ],
-      "tags": ["Konten YouTube", "Vlog", "Video Edukasi", "Film Pendek Ringan"],
+      "tags": [
+        "Konten YouTube",
+        "Vlog",
+        "Video Edukasi",
+        "Film Pendek Ringan"
+      ],
       "policies": [
         "Revisi gratis 2x. Lebih dari itu dikenakan IDR 15.000/revisi.",
         "Revisi hanya berlaku untuk perubahan minor sesuai brief awal.",
@@ -109,13 +122,13 @@
     {
       "id": 3,
       "name": "Paket Kreator",
-      "price": 150000,
+      "price": 249900,
       "revisions": 3,
       "durationText": "1–5 menit",
       "overRatePerMin": 32000,
       "leadTime": "3–5 hari",
       "workloadPerMin": 3,
-      "disabled": false, 
+      "disabled": false,
       "features": [
         "editing kompleks",
         "transisi dinamis",
@@ -124,7 +137,12 @@
         "motion graphics sederhana",
         "Gratis Revisi 3x"
       ],
-      "tags": ["Iklan Produk", "Cinematic", "Motion Graphics", "Video Musik"],
+      "tags": [
+        "Iklan Produk",
+        "Cinematic",
+        "Motion Graphics",
+        "Video Musik"
+      ],
       "policies": [
         "Revisi gratis 3x. Lebih dari itu dikenakan IDR 20.000/revisi.",
         "Revisi hanya berlaku untuk perubahan minor sesuai brief awal.",
@@ -141,24 +159,3 @@
     }
   ]
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## Summary
- apply psychological pricing to paid packages to make them more attractive

## Testing
- `jq '.' config/prices.json`

------
https://chatgpt.com/codex/tasks/task_e_68c7458894308327af321ab6bdd8fba0