### PR TITLE
Add written consent and flexible pricing policies

### DIFF
--- a/config/prices.json
+++ b/config/prices.json
@@ -41,7 +41,9 @@
         "Editor berhak menolak projek jika file RAW dinilai tidak berkualitas",
         "Klien tidak berhak complain atas hasil editing",
         "Copyright dipegang editor",
-        "Klien boleh memberi saran, tapi tidak mengikat editor"
+        "Klien boleh memberi saran, tapi tidak mengikat editor",
+        "Publikasi hasil pekerjaan untuk portofolio hanya dilakukan jika ada izin tertulis dari klien (bisa berupa chat/email).",
+        "Harga dapat dinegosiasikan dan disesuaikan berdasarkan kesepakatan bersama antara klien dan editor."
       ]
     },
     {
@@ -77,7 +79,9 @@
         "File kerja mentah (.prproj, .aep, dsb) tidak termasuk harga; diminta = biaya tambahan.",
         "Editor berhak pakai karya sebagai portofolio, kecuali ada perjanjian NDA.",
         "Revisi gratis jika kesalahan teknis dari editor (glitch, typo, salah potong scene).",
-        "Komunikasi & revisi dicatat via chat. Jam kerja: 09:00–22:00."
+        "Komunikasi & revisi dicatat via chat. Jam kerja: 09:00–22:00.",
+        "Publikasi hasil pekerjaan untuk portofolio hanya dilakukan jika ada izin tertulis dari klien (bisa berupa chat/email).",
+        "Harga dapat dinegosiasikan dan disesuaikan berdasarkan kesepakatan bersama antara klien dan editor."
       ]
     },
     {
@@ -116,7 +120,9 @@
         "File kerja mentah (.prproj, .aep, dsb) tidak termasuk harga; diminta = biaya tambahan.",
         "Editor berhak pakai karya sebagai portofolio, kecuali ada perjanjian NDA.",
         "Revisi gratis jika kesalahan teknis dari editor (glitch, typo, salah potong scene).",
-        "Komunikasi & revisi dicatat via chat. Jam kerja: 09:00–22:00."
+        "Komunikasi & revisi dicatat via chat. Jam kerja: 09:00–22:00.",
+        "Publikasi hasil pekerjaan untuk portofolio hanya dilakukan jika ada izin tertulis dari klien (bisa berupa chat/email).",
+        "Harga dapat dinegosiasikan dan disesuaikan berdasarkan kesepakatan bersama antara klien dan editor."
       ]
     },
     {
@@ -154,7 +160,9 @@
         "File kerja mentah (.prproj, .aep, dsb) tidak termasuk harga; diminta = biaya tambahan.",
         "Editor berhak pakai karya sebagai portofolio, kecuali ada perjanjian NDA.",
         "Revisi gratis jika kesalahan teknis dari editor (glitch, typo, salah potong scene).",
-        "Komunikasi & revisi dicatat via chat. Jam kerja: 09:00–22:00."
+        "Komunikasi & revisi dicatat via chat. Jam kerja: 09:00–22:00.",
+        "Publikasi hasil pekerjaan untuk portofolio hanya dilakukan jika ada izin tertulis dari klien (bisa berupa chat/email).",
+        "Harga dapat dinegosiasikan dan disesuaikan berdasarkan kesepakatan bersama antara klien dan editor."
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- add clarification that portfolio publishing requires written client consent
- note that pricing can be negotiated by agreement between client and editor

## Testing
- `npm test` *(fails: Could not read package.json: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c754a126d08327a4a2f81e3adc9836