### PR TITLE
feat: staggered portfolio fade-in animation

### DIFF
--- a/assets/portfolio.js
+++ b/assets/portfolio.js
@@ -69,4 +69,18 @@ function renderPortfolio(items){
   });
 }
 
-window.Portfolio = { loadAndRender: loadAndRenderPortfolio };
+function animatePortfolioItems(){
+  const items=document.querySelectorAll('#portfolio .portfolio-item');
+  items.forEach((el,i)=>{
+    setTimeout(()=>el.classList.add('show'),i*150);
+  });
+}
+
+function resetPortfolioItems(){
+  document.querySelectorAll('#portfolio .portfolio-item.show').forEach(el=>el.classList.remove('show'));
+}
+window.Portfolio = {
+  loadAndRender: loadAndRenderPortfolio,
+  animate: animatePortfolioItems,
+  reset: resetPortfolioItems
+};

--- a/index.html
+++ b/index.html
@@ -31,7 +31,18 @@
     /* ===== Portfolio ===== */
     .portfolio-section h2{margin:40px 0 16px;font-size:18px}
     .portfolio-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:20px}
-    .portfolio-item{background:var(--card);padding:12px;border-radius:12px}
+    .portfolio-item{
+      background:var(--card);
+      padding:12px;
+      border-radius:12px;
+      opacity:0;
+      transform:translateY(20px);
+      transition:opacity 0.4s ease,transform 0.4s ease;
+    }
+    .portfolio-item.show{
+      opacity:1;
+      transform:translateY(0);
+    }
     .portfolio-item .video-wrapper{position:relative;aspect-ratio:16/9} /* responsive 16:9 */
     .portfolio-item .video-wrapper iframe,
     .portfolio-item .video-wrapper video{position:absolute;top:0;left:0;width:100%;height:100%;border-radius:8px;background:#000;border:none} /* full-size media */
@@ -290,6 +301,11 @@
         const show=pfGrid.style.display==='none'; // determine state
         pfGrid.style.display=show?'':'none'; // show/hide list
         pfToggle.classList.toggle('active',show); // toggle diamond fill
+        if(show){
+          Portfolio.animate();
+        }else{
+          Portfolio.reset();
+        }
       }); // end handler
 
     const policyBtn=document.getElementById('policyBtn');


### PR DESCRIPTION
## Summary
- add CSS transitions and show class for portfolio items
- add animate/reset helpers and trigger staggered fade-in on toggle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fe21e4948327902e92e7784cf8cf