### PR TITLE
Add smooth fade-out animation for portfolio items

### DIFF
--- a/assets/portfolio.js
+++ b/assets/portfolio.js
@@ -80,6 +80,7 @@ function animatePortfolioItems(){
   const items=container.querySelectorAll('.portfolio-item');
   setTimeout(()=>{ // allow reflow before starting
     items.forEach((el,i)=>{
+      el.classList.remove('hide');
       setTimeout(()=>{
         el.classList.add('show');
       },i*150);
@@ -87,13 +88,23 @@ function animatePortfolioItems(){
   },50);
 }
 
-function resetPortfolioItems(){
+function hidePortfolioItems(){
   const container=document.getElementById('portfolio');
   if(!container) return;
-  container.querySelectorAll('.portfolio-item').forEach(el=>el.classList.remove('show'));
+  const items=container.querySelectorAll('.portfolio-item');
+  items.forEach((el,i)=>{
+    setTimeout(()=>{
+      el.classList.remove('show');
+      el.classList.add('hide');
+    },i*100);
+  });
+  setTimeout(()=>{
+    container.innerHTML='';
+    container.style.display='none';
+  },500);
 }
 window.Portfolio = {
   loadAndRender: loadAndRenderPortfolio,
   animate: animatePortfolioItems,
-  reset: resetPortfolioItems
+  hide: hidePortfolioItems
 };

--- a/index.html
+++ b/index.html
@@ -43,6 +43,11 @@
       opacity:1;
       transform:translateY(0);
     }
+    .portfolio-item.hide{
+      opacity:0;
+      transform:translateY(20px);
+      transition:opacity 0.4s ease,transform 0.4s ease;
+    }
     .portfolio-item .video-wrapper{position:relative;aspect-ratio:16/9} /* responsive 16:9 */
     .portfolio-item .video-wrapper iframe,
     .portfolio-item .video-wrapper video{position:absolute;top:0;left:0;width:100%;height:100%;border-radius:8px;background:#000;border:none} /* full-size media */
@@ -298,13 +303,14 @@
       const pfToggle=document.getElementById('pfToggle'); // get toggle label
       const pfGrid=document.getElementById('portfolio'); // get portfolio list
       pfToggle.addEventListener('click',()=>{ // attach click handler
-        const show=pfGrid.style.display==='none'; // determine state
-        pfGrid.style.display=show?'':'none'; // show/hide list
-        pfToggle.classList.toggle('active',show); // toggle diamond fill
-        if(show){
-          Portfolio.animate();
+        const hidden=pfGrid.style.display==='none'; // determine state
+        if(hidden){
+          pfGrid.style.display='';
+          pfToggle.classList.toggle('active',true); // toggle diamond fill
+          Portfolio.loadAndRender();
         }else{
-          Portfolio.reset();
+          pfToggle.classList.toggle('active',false); // toggle diamond fill
+          Portfolio.hide();
         }
       }); // end handler
 


### PR DESCRIPTION
## Summary
- add `.portfolio-item.hide` style and refine portfolio toggle logic
- implement sequential fade-out of portfolio items before clearing the grid

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c803eb112c8327b7dbf3ddc9d1f05c