### PR TITLE
Add Code Order search modal to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,36 @@
 
     .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:20px}
 
+    .order-search{
+      margin:24px 0;
+      display:flex;
+      flex-wrap:wrap;
+      gap:12px;
+      align-items:center;
+    }
+    .order-search input{
+      flex:1 1 220px;
+      min-width:220px;
+      padding:10px 14px;
+      border-radius:10px;
+      border:1px solid rgba(255,255,255,0.12);
+      background:var(--card);
+      color:#fff;
+      font-size:14px;
+    }
+    .order-search input::placeholder{color:var(--muted)}
+    .order-search button{
+      padding:10px 20px;
+      border-radius:10px;
+      border:none;
+      background:var(--accent);
+      color:#fff;
+      font-weight:600;
+      cursor:pointer;
+      transition:opacity .2s ease;
+    }
+    .order-search button:hover{opacity:.85}
+
     /* ===== Portfolio ===== */
     .portfolio-section h2{margin:40px 0 16px;font-size:18px}
     .portfolio-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:20px}
@@ -106,6 +136,19 @@
       font-size:13px;text-align:center;padding:8px 0;z-index:10}
     footer .footer-link{background:none;border:none;color:var(--muted);cursor:pointer;font-size:13px;text-decoration:underline}
 
+    .modal{display:none;position:fixed;z-index:1100;left:0;top:0;width:100%;height:100%;
+      background:rgba(0,0,0,0.6);backdrop-filter:blur(4px);align-items:center;justify-content:center;padding:20px}
+    .modal.show{display:flex}
+    .modal-content{background:var(--card);margin:auto;padding:24px;border-radius:12px;width:100%;max-width:480px;position:relative;
+      box-shadow:0 12px 32px rgba(0,0,0,0.45)}
+    .modal-content h3{margin-bottom:12px;font-size:18px}
+    .modal-content p{margin-bottom:8px;color:var(--muted);font-size:14px}
+    .modal-content p strong{color:#fff}
+    .modal .close{position:absolute;top:14px;right:18px;background:none;border:none;color:#fff;font-size:24px;cursor:pointer;line-height:1}
+    .modal-status{font-weight:700}
+    .modal-status.available{color:#4caf50}
+    .modal-status.unavailable{color:#f44336}
+
     .modal-overlay{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);
       backdrop-filter:blur(5px);display:flex;align-items:center;justify-content:center;padding:20px;z-index:1000;
       opacity:0;pointer-events:none;transition:opacity .3s ease-out}
@@ -146,6 +189,11 @@
       </div>
     </header>
 
+    <div class="order-search">
+      <input type="text" id="kodeInput" placeholder="Masukkan Code Order…" autocomplete="off">
+      <button type="button" id="searchBtn">Cari</button>
+    </div>
+
     <section class="grid" id="packages"></section>
 
     <section class="portfolio-section">
@@ -159,6 +207,16 @@
 
     <footer><button id="policyBtn" class="footer-link">Kebijakan & Panduan</button></footer>
   </main>
+
+  <div id="orderModal" class="modal" aria-hidden="true" role="dialog" aria-labelledby="orderModalTitle">
+    <div class="modal-content">
+      <button class="close" type="button" id="orderModalClose" aria-label="Tutup popup">&times;</button>
+      <div id="popup-isi">
+        <h3 id="orderModalTitle">Detail Code Order</h3>
+        <p>Masukkan Code Order untuk menampilkan detail.</p>
+      </div>
+    </div>
+  </div>
 
   <div id="policyModal" class="modal-overlay" aria-hidden="true">
     <div class="modal-box">
@@ -232,6 +290,120 @@
     },5000);
 
     const FLIP_DURATION=250;
+
+    const CSV_URL="https://docs.google.com/spreadsheets/d/e/2PACX-1vRZiGRgDxVjlJupwCAb29TPzNlksU5kISHLkmfpqbdwO_NQ__PEOk8FxuHe_UwzxWe5pcnfTJ1MFX3b/pub?gid=0&single=true&output=csv";
+    let orderRowsCache=null;
+
+    const orderModal=document.getElementById('orderModal');
+    const orderModalContent=document.getElementById('popup-isi');
+    const orderModalClose=document.getElementById('orderModalClose');
+    const kodeInput=document.getElementById('kodeInput');
+    const searchBtn=document.getElementById('searchBtn');
+
+    async function loadOrderRows(){
+      if(orderRowsCache) return orderRowsCache;
+      const response=await fetch(CSV_URL);
+      if(!response.ok) throw new Error(`Gagal memuat CSV: ${response.status}`);
+      const text=(await response.text()).trim();
+      orderRowsCache=parseCSV(text);
+      return orderRowsCache;
+    }
+
+    function parseCSV(text){
+      const rows=[];
+      let current=[];
+      let value='';
+      let insideQuotes=false;
+      for(let i=0;i<text.length;i++){
+        const char=text[i];
+        if(char==='"'){
+          if(insideQuotes && text[i+1]==='"'){ value+='"'; i++; }
+          else{ insideQuotes=!insideQuotes; }
+        }else if(char===',' && !insideQuotes){
+          current.push(value);
+          value='';
+        }else if((char==='\n' || char==='\r') && !insideQuotes){
+          if(char==='\r' && text[i+1]==='\n') i++;
+          current.push(value);
+          rows.push(current);
+          current=[];
+          value='';
+        }else{
+          value+=char;
+        }
+      }
+      if(value!=='' || current.length){
+        current.push(value);
+        rows.push(current);
+      }
+      return rows
+        .filter(row=>row.length&&row.some(cell=>cell.trim()!==''))
+        .map(row=>row.map(cell=>cell.trim()));
+    }
+
+    function openOrderModal(){
+      if(!orderModal) return;
+      orderModal.classList.add('show');
+      orderModal.setAttribute('aria-hidden','false');
+    }
+
+    function tutupPopup(){
+      if(!orderModal) return;
+      orderModal.classList.remove('show');
+      orderModal.setAttribute('aria-hidden','true');
+      if(kodeInput) kodeInput.focus();
+    }
+
+    async function cariData(){
+      const kodeDicari=(kodeInput?.value||'').trim();
+      if(!kodeDicari){ alert('Masukkan Code Order dulu'); return; }
+      if(orderModalContent){
+        orderModalContent.innerHTML=`
+          <h3 id="orderModalTitle">Detail Code Order</h3>
+          <p>Sedang mencari data...</p>
+        `;
+      }
+      openOrderModal();
+      try{
+        const rows=await loadOrderRows();
+        const dataRow=rows.slice(1).find(row=>(row[0]||'').trim().toLowerCase()===kodeDicari.toLowerCase());
+        if(orderModalContent){
+          if(dataRow){
+            const statusText=(dataRow[6]||'').trim();
+            const statusClass=statusText.toLowerCase()==='tersedia'?'available':'unavailable';
+            orderModalContent.innerHTML=`
+              <h3 id="orderModalTitle">Detail Code Order</h3>
+              <p><strong>Code Order:</strong> ${escapeHtml(dataRow[0]||'-')}</p>
+              <p><strong>Code Projek:</strong> ${escapeHtml(dataRow[1]||'-')}</p>
+              <p><strong>Tanggal Order:</strong> ${escapeHtml(dataRow[2]||'-')}</p>
+              <p><strong>Tanggal Selesai:</strong> ${escapeHtml(dataRow[3]||'-')}</p>
+              <p><strong>Expire Backup:</strong> ${escapeHtml(dataRow[4]||'-')}</p>
+              <p><strong>Judul:</strong> ${escapeHtml(dataRow[5]||'-')}</p>
+              <p><strong>Status:</strong> <span class="modal-status ${statusClass}">${escapeHtml(statusText||'-')}</span></p>
+            `;
+          }else{
+            orderModalContent.innerHTML=`
+              <h3 id="orderModalTitle">Detail Code Order</h3>
+              <p>Code Order tidak ditemukan.</p>
+            `;
+          }
+        }
+      }catch(error){
+        console.error('Error fetching order data:',error);
+        if(orderModalContent){
+          orderModalContent.innerHTML=`
+            <h3 id="orderModalTitle">Detail Code Order</h3>
+            <p>Terjadi kesalahan saat memuat data. Silakan coba lagi.</p>
+          `;
+        }
+      }
+    }
+
+    if(searchBtn) searchBtn.addEventListener('click',cariData);
+    if(kodeInput) kodeInput.addEventListener('keyup',e=>{ if(e.key==='Enter') cariData(); });
+    if(orderModalClose) orderModalClose.addEventListener('click',tutupPopup);
+    if(orderModal) orderModal.addEventListener('click',e=>{ if(e.target===orderModal) tutupPopup(); });
+    document.addEventListener('keydown',e=>{ if(e.key==='Escape'&&orderModal?.classList.contains('show')) tutupPopup(); });
 
     async function loadPackages(){
       try{ const {prices,promo}=await Pricing.loadConfig("."); renderPackages(prices.packages,promo); }


### PR DESCRIPTION
## Summary
- add a styled Code Order search input and modal container to the landing page
- implement CSV fetching, parsing, and status-aware rendering inside the modal

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cdeaade1348327bb9b4a0ddf4845ef