### PR TITLE
Rework order status modal layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,8 @@
     .logo img{width:44px;height:44px;border-radius:8px;object-fit:cover}
     h1{font-size:18px}
     p.lead{color:var(--muted);font-size:13px;margin-top:4px;min-height:16px;transition:opacity .5s ease}
+    .order-check-btn{padding:6px 12px;background:var(--accent);color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:13px;font-weight:600;white-space:nowrap}
+    .order-check-btn:focus-visible{outline:2px solid rgba(255,0,114,0.6);outline-offset:2px}
 
     .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:20px}
 
@@ -113,6 +115,9 @@
     .modal.show{display:flex}
     .modal-content{background:var(--card);margin:auto;padding:24px;border-radius:12px;width:100%;max-width:480px;position:relative;
       box-shadow:0 12px 32px rgba(0,0,0,0.45)}
+    .modal-form{margin-top:12px;display:flex;flex-wrap:wrap;gap:10px;align-items:center}
+    .modal-form input{width:250px;padding:6px 10px;background:var(--card);color:#fff;border:1px solid var(--accent);border-radius:6px;outline:none}
+    .modal-form button{padding:6px 12px;background:var(--accent);color:#fff;border:none;border-radius:6px;cursor:pointer;font-weight:600}
     .modal-content h3{margin-bottom:12px;font-size:18px}
     .modal-content p{margin-bottom:8px;color:var(--muted);font-size:14px}
     .modal-content p strong{color:#fff}
@@ -120,6 +125,9 @@
     .modal-status{font-weight:700}
     .modal-status.available{color:#4caf50}
     .modal-status.unavailable{color:#f44336}
+    #popup-isi{margin-top:16px;font-size:14px}
+    #popup-isi p{margin-bottom:8px}
+    #popup-isi p:last-child{margin-bottom:0}
 
     .modal-overlay{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);
       backdrop-filter:blur(5px);display:flex;align-items:center;justify-content:center;padding:20px;z-index:1000;
@@ -150,16 +158,6 @@
   </style>
 </head>
 <body>
-  <div style="position:fixed;top:20px;right:20px;display:flex;gap:8px;z-index:999;align-items:center;">
-    <input id="kodeInput" type="text" placeholder="Input Code Order"
-      style="width:250px;padding:6px 10px;border-radius:6px;border:1px solid #ff0072;outline:none;background:var(--card);color:#fff;"
-      autocomplete="off">
-    <button id="searchBtn" type="button"
-      style="padding:6px 12px;background:#ff0072;color:#fff;border:none;border-radius:6px;cursor:pointer;font-weight:600;">
-      Cek Ketersediaan File
-    </button>
-  </div>
-
   <main class="container">
     <header>
       <div class="brand">
@@ -169,6 +167,7 @@
           <p class="lead" id="rotating-text">Hasil bisa di lihat di portofolio</p>
         </div>
       </div>
+      <button id="openOrderBtn" type="button" class="order-check-btn">Cek Status Order</button>
     </header>
 
     <section class="grid" id="packages"></section>
@@ -188,8 +187,12 @@
   <div id="orderModal" class="modal" aria-hidden="true" role="dialog" aria-labelledby="orderModalTitle">
     <div class="modal-content">
       <button class="close" type="button" id="orderModalClose" aria-label="Tutup popup">&times;</button>
+      <h3 id="orderModalTitle">Cek Ketersediaan File</h3>
+      <div class="modal-form">
+        <input id="kodeInput" type="text" placeholder="Input Code Order" autocomplete="off">
+        <button id="searchBtn" type="button">Cek Ketersediaan File</button>
+      </div>
       <div id="popup-isi">
-        <h3 id="orderModalTitle">Detail Code Order</h3>
         <p>Masukkan Code Order untuk menampilkan detail.</p>
       </div>
     </div>
@@ -276,6 +279,8 @@
     const orderModalClose=document.getElementById('orderModalClose');
     const kodeInput=document.getElementById('kodeInput');
     const searchBtn=document.getElementById('searchBtn');
+    const openOrderBtn=document.getElementById('openOrderBtn');
+    const defaultOrderMessage='<p>Masukkan Code Order untuk menampilkan detail.</p>';
 
     async function loadOrderRows(){
       if(orderRowsCache) return orderRowsCache;
@@ -322,23 +327,21 @@
       if(!orderModal) return;
       orderModal.classList.add('show');
       orderModal.setAttribute('aria-hidden','false');
+      if(kodeInput) kodeInput.focus();
     }
 
     function tutupPopup(){
       if(!orderModal) return;
       orderModal.classList.remove('show');
       orderModal.setAttribute('aria-hidden','true');
-      if(kodeInput) kodeInput.focus();
+      if(openOrderBtn) openOrderBtn.focus();
     }
 
     async function cariData(){
       const kodeDicari=(kodeInput?.value||'').trim();
       if(!kodeDicari){ alert('Masukkan Code Order dulu'); return; }
       if(orderModalContent){
-        orderModalContent.innerHTML=`
-          <h3 id="orderModalTitle">Detail Code Order</h3>
-          <p>Sedang mencari data...</p>
-        `;
+        orderModalContent.innerHTML='<p>Sedang mencari data...</p>';
       }
       openOrderModal();
       try{
@@ -349,7 +352,6 @@
             const statusText=(dataRow[6]||'').trim();
             const statusClass=statusText.toLowerCase()==='tersedia'?'available':'unavailable';
             orderModalContent.innerHTML=`
-              <h3 id="orderModalTitle">Detail Code Order</h3>
               <p><strong>Code Order:</strong> ${escapeHtml(dataRow[0]||'-')}</p>
               <p><strong>Code Projek:</strong> ${escapeHtml(dataRow[1]||'-')}</p>
               <p><strong>Tanggal Order:</strong> ${escapeHtml(dataRow[2]||'-')}</p>
@@ -359,23 +361,22 @@
               <p><strong>Status:</strong> <span class="modal-status ${statusClass}">${escapeHtml(statusText||'-')}</span></p>
             `;
           }else{
-            orderModalContent.innerHTML=`
-              <h3 id="orderModalTitle">Detail Code Order</h3>
-              <p>Code Order tidak ditemukan atau file tidak tersedia.</p>
-            `;
+            orderModalContent.innerHTML='<p>Code Order tidak ditemukan atau file tidak tersedia.</p>';
           }
         }
       }catch(error){
         console.error('Error fetching order data:',error);
         if(orderModalContent){
-          orderModalContent.innerHTML=`
-            <h3 id="orderModalTitle">Detail Code Order</h3>
-            <p>Terjadi kesalahan saat memuat data. Silakan coba lagi.</p>
-          `;
+          orderModalContent.innerHTML='<p>Terjadi kesalahan saat memuat data. Silakan coba lagi.</p>';
         }
       }
     }
 
+    if(openOrderBtn) openOrderBtn.addEventListener('click',()=>{
+      if(orderModalContent) orderModalContent.innerHTML=defaultOrderMessage;
+      if(kodeInput){ kodeInput.value=''; }
+      openOrderModal();
+    });
     if(searchBtn) searchBtn.addEventListener('click',cariData);
     if(kodeInput) kodeInput.addEventListener('keyup',e=>{ if(e.key==='Enter') cariData(); });
     if(orderModalClose) orderModalClose.addEventListener('click',tutupPopup);


### PR DESCRIPTION
## Summary
- replace the floating order status form with a compact header button
- move the order lookup input and action into a modal with updated styling
- adjust the lookup script to drive the new modal flow while preserving CSV search

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cdf70b730c8327bf25043aad105383