### PR TITLE
Adjust backup request button availability

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,8 +131,9 @@
     #popup-isi{margin-top:16px;font-size:14px}
     #popup-isi p{margin-bottom:8px}
     #popup-isi p:last-child{margin-bottom:0}
-    #backupRequestBtn{margin-top:16px;font-size:13px;display:inline-flex;align-items:center;justify-content:center}
-    #backupRequestBtn[disabled]{background:var(--disabled)!important;color:#aaa;cursor:not-allowed;pointer-events:none}
+    #backupRequestBtn{margin-top:16px;font-size:13px;display:block;text-align:center}
+    #backupRequestBtn[disabled],
+    #backupRequestBtn.disabled{background:var(--disabled)!important;color:#aaa;cursor:not-allowed;pointer-events:none}
 
     .modal-overlay{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);
       backdrop-filter:blur(5px);display:flex;align-items:center;justify-content:center;padding:20px;z-index:1000;
@@ -319,14 +320,19 @@
       if(backupRequestBtn){
         backupRequestBtn.style.display='none';
         backupRequestBtn.disabled=true;
+        backupRequestBtn.classList.remove('disabled');
       }
       lastOrderData=null;
     }
 
-    function showBackupRequestButton(){
+    function updateBackupRequestButton(statusProgres,statusFile){
       if(!backupRequestBtn) return;
-      backupRequestBtn.style.display='inline-flex';
-      backupRequestBtn.disabled=false;
+      const progressValue=String(statusProgres||'').trim();
+      const fileValue=String(statusFile||'').trim();
+      const canRequestBackup=progressValue==='Approved'&&fileValue==='File Tersedia';
+      backupRequestBtn.style.display='block';
+      backupRequestBtn.disabled=!canRequestBackup;
+      backupRequestBtn.classList.toggle('disabled',!canRequestBackup);
     }
 
     async function ensurePriceConfig(){
@@ -490,14 +496,8 @@
             html+=`<p><strong>Code Order:</strong> ${escapeHtml(rowData.codeOrder)}</p>`;
 
             orderModalContent.innerHTML=html;
-            const canRequestBackup=statusFileNormalized.startsWith('file tersedia');
-            if(canRequestBackup){
-              lastOrderData=rowData;
-              showBackupRequestButton();
-            }else{
-              lastOrderData=null;
-              hideBackupRequestButton();
-            }
+            lastOrderData=rowData;
+            updateBackupRequestButton(rowData.statusProgres,rowData.statusFile);
           }else{
             orderModalContent.innerHTML='<p>Code Order tidak ditemukan silahkan konfirmasi ke Freelancer.</p>';
             hideBackupRequestButton();


### PR DESCRIPTION
## Summary
- show the backup request button after fetching order details while defaulting it to hidden
- enable the button only when progress is Approved and the file status is File Tersedia, otherwise keep it disabled with Kuota Habis styling
- update button styling to use block display and share the disabled appearance

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ce3ea5b29883279f0a040d98497ae1