### PR TITLE
Update work schedule popup styling

### DIFF
--- a/assets/schedule.js
+++ b/assets/schedule.js
@@ -46,9 +46,12 @@
       const currentMinutes=parseTimeToMinutes(normalizedTime);
       const isOpen=currentMinutes!==null&&currentMinutes>=bukaMinutes&&currentMinutes<tutupMinutes;
       const statusLabel=isOpen?"Buka":"Tutup";
-      statusElement.textContent=`Status: ${statusLabel} (${formatJam(todaySchedule.buka)} – ${formatJam(todaySchedule.tutup)})`;
+      const statusClass=isOpen?"status-open":"status-closed";
+      const bukaLabel=formatJam(todaySchedule.buka);
+      const tutupLabel=formatJam(todaySchedule.tutup);
+      statusElement.innerHTML=`<span class="status-label">Status:</span> <span class="status-text ${statusClass}">${statusLabel}</span> <span class="status-time">(${bukaLabel} – ${tutupLabel})</span>`;
     }else{
-      statusElement.textContent="Status: Jadwal tidak tersedia";
+      statusElement.innerHTML='<span class="status-label">Status:</span> <span class="status-text">Jadwal tidak tersedia</span>';
     }
   }
 
@@ -58,14 +61,22 @@
     }
 
     listElement.innerHTML="";
+    listElement.classList.add("jadwal-list");
     DAY_NAMES.forEach((dayName)=>{
       const item=document.createElement("li");
+      item.className="jadwal-item";
+      const dayLabel=document.createElement("span");
+      dayLabel.className="jadwal-hari";
+      dayLabel.textContent=dayName;
+      const timeLabel=document.createElement("span");
+      timeLabel.className="jadwal-jam";
       const info=schedule&&schedule[dayName];
       if(info&&typeof info.buka!=="undefined"&&typeof info.tutup!=="undefined"){
-        item.textContent=`${dayName}: ${formatJam(info.buka)} – ${formatJam(info.tutup)}`;
+        timeLabel.textContent=`${formatJam(info.buka)} – ${formatJam(info.tutup)}`;
       }else{
-        item.textContent=`${dayName}: -`;
+        timeLabel.textContent="-";
       }
+      item.append(dayLabel,timeLabel);
       listElement.appendChild(item);
     });
   }

--- a/index.html
+++ b/index.html
@@ -170,14 +170,92 @@
     }
     #popup-jadwal.modal.tersembunyi{display:none;}
     #popup-jadwal .konten-modal{
-      background:#232323;padding:20px;border-radius:12px;
-      color:#fff;max-width:450px;text-align:center;
+      background:#232323;
+      padding:28px 32px;
+      border-radius:16px;
+      color:#fff;
+      max-width:480px;
+      width:100%;
       position:relative;
+      text-align:left;
+      box-shadow:0 18px 42px rgba(0,0,0,0.55);
+      display:flex;
+      flex-direction:column;
+      gap:16px;
+    }
+    #popup-jadwal .modal-heading{
+      display:flex;
+      flex-direction:column;
+      gap:12px;
+      padding-right:24px;
+    }
+    #popup-jadwal .modal-heading h2{
+      font-size:22px;
+      margin:0;
     }
     #popup-jadwal #tutup-jadwal{
-      position:absolute;top:10px;right:20px;
-      background:none;border:none;color:#fff;font-size:24px;cursor:pointer;
+      position:absolute;
+      top:18px;
+      right:22px;
+      background:rgba(255,255,255,0.08);
+      border:none;
+      color:#fff;
+      font-size:20px;
+      cursor:pointer;
+      width:36px;
+      height:36px;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      border-radius:50%;
+      transition:background .2s ease;
     }
+    #popup-jadwal #tutup-jadwal:hover{
+      background:rgba(255,255,255,0.16);
+    }
+    #popup-jadwal .status-wrapper{
+      display:flex;
+      align-items:center;
+      gap:10px;
+      flex-wrap:wrap;
+      font-size:16px;
+      font-weight:600;
+    }
+    #popup-jadwal .status-label{color:var(--muted);font-weight:600;}
+    #popup-jadwal .status-text{font-weight:700;}
+    #popup-jadwal .status-open{color:#4caf50;}
+    #popup-jadwal .status-closed{color:#f44336;}
+    #popup-jadwal .status-time{color:var(--muted);font-weight:500;}
+    #popup-jadwal #jam-realtime{
+      font-size:20px;
+      font-weight:700;
+    }
+    #popup-jadwal .jadwal-section h3{
+      margin-bottom:12px;
+    }
+    #popup-jadwal .jadwal-section{
+      display:flex;
+      flex-direction:column;
+      gap:12px;
+    }
+    #popup-jadwal .jadwal-list{
+      list-style:none;
+      padding:0;
+      margin:0;
+      display:flex;
+      flex-direction:column;
+      gap:4px;
+    }
+    #popup-jadwal .jadwal-item{
+      display:flex;
+      justify-content:space-between;
+      align-items:center;
+      gap:20px;
+      font-size:17px;
+      line-height:1.6;
+    }
+    #popup-jadwal .jadwal-hari{font-weight:600;}
+    #popup-jadwal .jadwal-jam{font-weight:600;color:var(--muted);margin-left:auto;text-align:right;min-width:120px;}
   </style>
 </head>
 <body>
@@ -283,12 +361,16 @@
 
   <div id="popup-jadwal" class="modal tersembunyi">
     <div class="konten-modal">
-      <button id="tutup-jadwal">×</button>
-      <h2>Jadwal Kerja</h2>
-      <p id="status-jadwal"></p>
+      <button id="tutup-jadwal" aria-label="Tutup jadwal">×</button>
+      <div class="modal-heading">
+        <h2>Jadwal Kerja</h2>
+        <div id="status-jadwal" class="status-wrapper" aria-live="polite"></div>
+      </div>
       <p id="jam-realtime"></p>
-      <h3>Jadwal Lengkap</h3>
-      <ul id="jadwal-lengkap"></ul>
+      <div class="jadwal-section">
+        <h3>Jadwal Lengkap</h3>
+        <ul id="jadwal-lengkap" class="jadwal-list"></ul>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- restyle the work schedule popup with additional padding, typography tweaks, and layout improvements for readability
- highlight open and closed statuses with bold colored text and enlarge the real-time clock display
- present the full weekly schedule using a two-column flex layout with generous line spacing

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cf65507f54832784d763a7f2b8bf7a